### PR TITLE
Change "scroll" overflow to "auto" overflow

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -868,7 +868,7 @@ nav#TOC > input:checked + ul {
 
     max-width: calc((100vw - var(--main-width)) / 2 - 2 * var(--line-height));
     max-height: calc(100vh - 2 * var(--line-height));
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   nav#TOC label {
@@ -952,7 +952,7 @@ nav#TOC > input:checked + ul {
 
   .wide {
     width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .wide.extra-wide {
@@ -1007,7 +1007,7 @@ nav#TOC > input:checked + ul {
 
   .wide {
     width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
   }
 
@@ -1073,7 +1073,7 @@ nav#TOC > input:checked + ul {
 
   .wide {
     width: var(--main-width);
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
   }
 
@@ -1125,7 +1125,7 @@ nav#TOC > input:checked + ul {
 
   .wide {
     width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
   }
 


### PR DESCRIPTION
I was looking at the page with my Mac set to always show scrollbars, which is different from the default macOS behavior to hide scroll bars by default and only show them when interacted with.

With this setting, the TOC and any wide content blocks are displayed with scroll bars regardless of whether or not the content can scroll. This is distracting.

<img width="1462" alt="Screenshot 2022-12-15T09 50 50" src="https://user-images.githubusercontent.com/3058200/207896913-9d36eab6-95a7-4fea-97a3-f41152ef3796.png">

The `overflow-x: scroll` and `overflow-y: scroll` CSS declarations are the culprit here. When overflow rules are set to `scroll`:
 
> Browsers always display scrollbars whether or not any content is actually clipped, preventing scrollbars from appearing or disappearing as content changes. ([src](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#values))

When the values are set to `auto`, browsers will only display a scroll bar if the content overflows.

When I used the web inspector to change the overflow-y value of the TOC to auto, it did what I expected:

<table><tr><td>
<img width="198" alt="Screenshot 2022-12-15T09 51 35" src="https://user-images.githubusercontent.com/3058200/207897570-839e87ba-6037-40ac-ad32-f1ecd74cbc8d.png">
</td><td>
<img width="160" alt="Screenshot 2022-12-15T09 51 47" src="https://user-images.githubusercontent.com/3058200/207897538-834bf781-2453-460c-aeea-ecc833fec2ec.png">
</td></tr></table>

And for wide content:

<img width="1456" alt="Screenshot 2022-12-15T10 16 57" src="https://user-images.githubusercontent.com/3058200/207897793-ed330c6c-c29a-4627-9f40-617af494210d.png">