### PR TITLE
[RFC] Add dynamic/persistent color scheme change support

### DIFF
--- a/docs/css/theme.css
+++ b/docs/css/theme.css
@@ -182,6 +182,10 @@ body {
   display: none;
 }
 
+strong#color-scheme-button {
+  cursor: pointer;
+}
+
 @media (prefers-color-scheme: dark) {
   .only-light-mode {
     display: none;

--- a/docs/features/index.html
+++ b/docs/features/index.html
@@ -41,7 +41,9 @@
 
 <nav id="TOC" role="doc-toc">
     <a href="..">← Return home</a><br>
-    <strong>Contents</strong><label for="contents">⊕</label>
+    <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
+  <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   <ul>
   <li><a href="#document-metadata" id="toc-document-metadata">Document metadata</a></li>
@@ -660,6 +662,8 @@ Typing rules for System F, From PFPL Chapter 16
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -705,6 +709,72 @@ Typing rules for System F, From PFPL Chapter 16
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,9 @@
 </header>
 
 <nav id="TOC" role="doc-toc">
-    <strong>Contents</strong><label for="contents">⊕</label>
+    <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
+  <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   <ul>
   <li><a href="#features" id="toc-features">Features</a></li>
@@ -169,6 +171,8 @@
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -214,6 +218,72 @@
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 </body>

--- a/docs/kitchen-sink/index.html
+++ b/docs/kitchen-sink/index.html
@@ -41,7 +41,9 @@
 
 <nav id="TOC" role="doc-toc">
     <a href="..">← Return home</a><br>
-    <strong>Contents</strong><label for="contents">⊕</label>
+    <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
+  <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   <ul>
   <li><a href="#prose" id="toc-prose">Prose</a></li>
@@ -1232,6 +1234,8 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -1277,6 +1281,72 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 </body>

--- a/docs/paper/index.html
+++ b/docs/paper/index.html
@@ -36,7 +36,9 @@
 
 <nav id="TOC" role="doc-toc">
     <a href="..">← Return home</a><br>
-    <strong>Contents</strong><label for="contents">⊕</label>
+    <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
+  <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   <ul>
   <li><a href="#prose" id="toc-prose">Prose</a></li>
@@ -853,6 +855,8 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -898,6 +902,72 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 </body>

--- a/docs/tufte/index.html
+++ b/docs/tufte/index.html
@@ -42,7 +42,9 @@
 
 <nav id="TOC" role="doc-toc">
     <a href="..">← Return home</a><br>
-    <strong>Contents</strong><label for="contents">⊕</label>
+    <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
+  <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   <ul>
   <li><a href="#prose" id="toc-prose">Prose</a></li>
@@ -939,6 +941,8 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -984,6 +988,72 @@ Meanwhile, <code>wide</code> will expand past the right column when the center c
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 </body>

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -182,6 +182,10 @@ body {
   display: none;
 }
 
+strong#color-scheme-button {
+  cursor: pointer;
+}
+
 @media (prefers-color-scheme: dark) {
   .only-light-mode {
     display: none;

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -860,7 +860,9 @@ figure > img, figure > pre, figure > div.sourceCode, figure:not(.wide) > div.sou
 }
 
 img {
-  width: 100%;
+  object-fit: contain;
+  max-width: 100%;
+  height: auto;
   display: block;
 }
 

--- a/template.html5
+++ b/template.html5
@@ -58,6 +58,8 @@ $if(toc)$
   $if(return-url)$
   <a href="$return-url$">$if(return-text)$$return-text$$else$← Return$endif$</a><br>
   $endif$
+  <!-- Set in Javascript. Left empty if Javascript is disabled -->
+  <strong id="color-scheme-button"></strong>
   <strong>Contents</strong><label for="contents">⊕</label>
   <input type="checkbox" id="contents">
   $table-of-contents$
@@ -85,6 +87,8 @@ $endif$
     checkbox.disabled = false;
     checkbox.addEventListener('click', (ev) => {ev.target.checked = wasChecked});
   });
+  var colorSchemeButton = document.getElementById('color-scheme-button');
+  var colorSchemeState = null;
 
   function hoistAbove() {
     const toHoist = document.querySelectorAll('main > .sidenote-wrapper + :not(.sidenote-wrapper)');
@@ -130,6 +134,72 @@ $endif$
       prevSize = newSize;
     });
   }
+
+  function applyPreferredColorScheme(scheme) {
+    for (var s = 0; s < document.styleSheets.length; s++) {
+      try {
+        for (var i = 0; i < document.styleSheets[s].cssRules.length; i++) {
+          rule = document.styleSheets[s].cssRules[i];
+
+          if (rule && rule.media && rule.media.mediaText.includes("prefers-color-scheme")) {
+            switch (scheme) {
+            case "light":
+              rule.media.appendMedium("original-prefers-color-scheme");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("dark")) rule.media.deleteMedium("(prefers-color-scheme: dark)");
+              break;
+            case "dark":
+              rule.media.appendMedium("(prefers-color-scheme: light)");
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            default:
+              rule.media.appendMedium("(prefers-color-scheme: dark)");
+              if (rule.media.mediaText.includes("light")) rule.media.deleteMedium("(prefers-color-scheme: light)");
+              if (rule.media.mediaText.includes("original")) rule.media.deleteMedium("original-prefers-color-scheme");
+              break;
+            }
+          }
+        }
+      } catch (e) {
+        // Silently skip cross-origin sheets
+      }
+    }
+  }
+
+  function onColorSchemeChange() {
+    if (colorSchemeState === 1) {
+      colorSchemeButton.innerText = '😎';
+      colorSchemeButton.title = 'light color scheme';
+      applyPreferredColorScheme('light');
+    } else if (colorSchemeState === 2) {
+      colorSchemeButton.innerText = '🌙';
+      colorSchemeButton.title = 'dark color scheme';
+      applyPreferredColorScheme('dark');
+    } else {
+      colorSchemeButton.innerText = '◯';
+      colorSchemeButton.title = 'system default color scheme';
+      applyPreferredColorScheme(null);
+    }
+  }
+
+  colorSchemeButton.addEventListener('click', function() {
+    if (colorSchemeState === null) {
+      colorSchemeState = 1;
+    } else if (colorSchemeState === 1) {
+      colorSchemeState = 2;
+    } else {
+      colorSchemeState = null;
+    }
+
+    window.localStorage.setItem('isDarkColorScheme', colorSchemeState);
+    onColorSchemeChange();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    colorSchemeState = parseInt(window.localStorage.getItem('isDarkColorScheme'));
+    onColorSchemeChange();
+  });
 })();
 </script>
 $for(include-after)$


### PR DESCRIPTION
**SEIZURE WARNING**

[2026-09-01_12-01-10.webm](https://github.com/user-attachments/assets/61879d8c-1506-4ed3-96ea-c6fa259e02a8)

---

Add a pseudo-button next to the "Contents" in the TOC nav area. The button is not shown if Javascript is disabled. If enabled, '◯' denotes that the color scheme follows the system default which was the default behaviour. '😎' denotes that the color scheme overridden to the 'light' mode. '🌙' denotes that the color scheme is overridden to the 'dark' mode.

The change is saved to the HTML5 localStorage and restores on next page load. Failure to reference localStorage object should have the same effect as Javascript being disabled as a fallback mechanism.

No impact on printed media.